### PR TITLE
resolved CICD issue for publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -31,7 +31,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: github.ref == 'refs/heads/main' # only publish to PyPI on a push from main
+    if: github.ref == 'refs/heads/master' # only publish to PyPI on a push from master
     needs:
     - build
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "qnngds"
-version = "1.0.0"
+version = "1.0.1"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },


### PR DESCRIPTION
modified publish-to-test-pypi.yml: 
From 'refs/heads/**main**' to 'refs/heads/**master**'