### PR TITLE
use checkout action to get access to repo files for fixing release naming

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -63,6 +63,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for sigstore
 
     steps:
+      - uses: actions/checkout@v4
     - name: Download all the dists
       uses: actions/download-artifact@v3
       with:
@@ -74,10 +75,14 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
+    - name: print directory
+      run: |
+        ls -la
+        pwd
     - name: Get project version
       id: getversion 
       run: >-
-        version=$(grep 'version = "[0-9\.]*"' ../../pyproject.toml | sed -n 's/[^0-9]*\([0-9\.]*\).*/\1/p')
+        version=$(grep 'version = "[0-9\.]*"' pyproject.toml | sed -n 's/[^0-9]*\([0-9\.]*\).*/\1/p')
         echo "$version" >> $GITHUB_OUTPUT
     - name: Create GitHub Release
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "qnngds"
-version = "1.0.6"
+version = "1.0.7"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },


### PR DESCRIPTION
okay hopefully it works this time. From what I'm reading: ([1](https://stackoverflow.com/questions/64405836/github-actions-no-such-file-or-directory-on-any-run-step), [2](https://github.com/orgs/community/discussions/25234)), it looks like the action runs at the repository root, so I also updated the grep script to run on `pyproject.toml`, not `../../pyproject.toml`