### PR TITLE
update documentation for SNSPD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "qnngds"
-version = "3.1.0"
+version = "3.1.1"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },

--- a/src/qnngds/devices/snspd.py
+++ b/src/qnngds/devices/snspd.py
@@ -9,7 +9,7 @@ from typing import Tuple, Optional, Union
 def basic(
     wire_width: float = 0.2,
     wire_pitch: float = 0.6,
-    size: Tuple[Union[int, float], Union[int, float]] = (6, 10),
+    size: Tuple[Optional[Union[int, float]], Optional[Union[int, float]]] = (6, 10),
     num_squares: Optional[int] = None,
     turn_ratio: Union[int, float] = 4,
     terminals_same_side: bool = False,
@@ -22,7 +22,7 @@ def basic(
     Parameters:
         wire_width (float): Width of the nanowire.
         wire_pitch (float): Pitch of the nanowire.
-        size (tuple of int or float): Size of the detector in squares (width, height).
+        size (tuple of Optional[int or float]): Size of the detector in squares (width, height).
         num_squares (Optional[int]): Number of squares in the detector.
         turn_ratio (int or float): Specifies how much of the SNSPD width is
             dedicated to the 180 degree turn. A turn_ratio of 10 will result in 20%
@@ -51,59 +51,6 @@ def basic(
         turn_ratio=turn_ratio,
         terminals_same_side=terminals_same_side,
         layer=layer,
-    )
-    ports = SNSPD.ports
-    SNSPD = pg.union(SNSPD, layer=layer)
-    SNSPD.ports = ports
-    SNSPD.name = f"SNSPD.BASIC(w={wire_width}, pitch={wire_pitch})"
-    return SNSPD
-
-
-def basic(
-    wire_width: float = 0.2,
-    wire_pitch: float = 0.6,
-    size: Tuple[Union[int, float], Union[int, float]] = (6, 10),
-    num_squares: Optional[int] = None,
-    turn_ratio: Union[int, float] = 4,
-    terminals_same_side: bool = False,
-    layer: int = 1,
-) -> Device:
-    """Creates an optimally-rounded SNSPD.
-
-    Takes Phidl's snspd, perform a union and rename it.
-
-    Parameters:
-        wire_width (float): Width of the nanowire.
-        wire_pitch (float): Pitch of the nanowire.
-        size (tuple of int or float): Size of the detector in squares (width, height).
-        num_squares (Optional[int]): Number of squares in the detector.
-        turn_ratio (int or float): Specifies how much of the SNSPD width is
-            dedicated to the 180 degree turn. A turn_ratio of 10 will result in 20%
-            of the width being comprised of the turn.
-        terminals_same_side (bool): If True, both ports will be located on the
-            same side of the SNSPD.
-        layer (int): Layer for the device to be created on.
-
-    Returns:
-        Device: A Device containing an optimally-rounded SNSPD, as provided by
-        Phidl but renamed and unified.
-    """
-    # check parameters constrains
-    if wire_pitch <= wire_width:
-        print(
-            "Warning, wire_pitch cannot be smaller than wire_pitch. "
-            "Choosing wire_pitch = 2*wire_width."
-        )
-        wire_pitch = 2 * wire_width
-
-    SNSPD = pg.snspd(
-        wire_width,
-        wire_pitch,
-        size,
-        num_squares,
-        turn_ratio,
-        terminals_same_side,
-        layer,
     )
     ports = SNSPD.ports
     SNSPD = pg.union(SNSPD, layer=layer)


### PR DESCRIPTION
Phidl allows for optional size/height + squares constraint.
e.g. `size = (5, None), num_squares=20` would give a 5um-wide SNSPD with 20 squares

Also removed copied definition