### PR TITLE
pass through ports to allow for partial application of extend_ports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 [project]
 name = "qnngds"
 
-version = "5.0.9"
+version = "5.0.8"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 [project]
 name = "qnngds"
 
-version = "5.0.7"
+version = "5.0.9"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },

--- a/src/qnngds/utilities.py
+++ b/src/qnngds/utilities.py
@@ -33,6 +33,7 @@ def extend_ports(
             `DeviceSpec` to generate the tapers. Determines the `start_width` automatically from
             `device`.
         new_ports (bool): if True, create new ports, using port `2` from `Device` specified by `extension`.
+            Also passes any non-extended ports through to the new device that is returned.
 
     Returns:
         (Device): the original device with ports extended

--- a/src/qnngds/utilities.py
+++ b/src/qnngds/utilities.py
@@ -65,6 +65,15 @@ def extend_ports(
             dev_extended.add_port(
                 port=ext_i.ports[2], name=port_name, layer=dev_i.ports[port_name].layer
             )
+    if new_ports:
+        for _, port in dev_i.ports.items():
+            if port.name in port_names:
+                continue
+            dev_extended.add_port(
+                port=port,
+                name=port.name,
+                layer=port.layer,
+            )
     dev_extended.name = "ext_port_" + device.name
     return dev_extended
 


### PR DESCRIPTION
# Before merging the pull request, please confirm the following
- [x] You have read the contribution guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html)
- [x] All newly defined `Device`s are tagged with the `@qg.device` decorator.
- [x] You have verified the documentation looks okay on readthedocs. See the linked action  in this PR labeled "docs/readthedocs.org:qnngds" for a link.
- [x] You have chosen an appropriate semantic version following the guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html#satisfied-with-your-code-ready-for-a-pull-request) and have updated pyproject.toml accordingly
