### PR TITLE
[WIP] tron improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 [project]
 name = "qnngds"
 
-version = "5.1.3"
+version = "5.1.4"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },

--- a/src/qnngds/devices/ntron.py
+++ b/src/qnngds/devices/ntron.py
@@ -97,6 +97,7 @@ def sharp(
     channel_sq: float = 1,
     source_sq: float = 5,
     drain_sq: float = 5,
+    symmetric: bool = True,
     layer: LayerSpec = (1, 0),
 ) -> Device:
     """Creates a sharp ntron device.
@@ -111,6 +112,8 @@ def sharp(
         source_sq (float): Length of the source region in squares.
         drain_w (float): Width of the drain region.
         drain_sq (float): Length of the drain region in squares.
+        symmetric (bool): symmetrically taper from source/drain width to channel.
+            default True.
         layer (LayerSpec): GDS layer specification
 
     Returns:
@@ -137,7 +140,8 @@ def sharp(
     c.connect(port=c.ports["W"], destination=k.ports[2])
     D.move(c.center, (0, 0))
 
-    drain = qg.geometries.taper(
+    taper_fun = qg.geometries.taper if symmetric else qg.geometries.ramp
+    drain = taper_fun(
         length=drain_l,
         start_width=channel_w,
         end_width=drain_w,
@@ -146,12 +150,13 @@ def sharp(
     d = D << drain
     d.connect(port=d.ports[1], destination=c.ports["N"])
 
-    source = qg.geometries.taper(
+    source = taper_fun(
         length=source_l,
         start_width=channel_w,
         end_width=source_w,
         layer=layer,
     )
+    source.mirror((0, 0), (0, 1))
     s = D << source
     s.connect(port=s.ports[1], destination=c.ports["S"])
 

--- a/src/qnngds/devices/snspd.py
+++ b/src/qnngds/devices/snspd.py
@@ -40,6 +40,7 @@ def basic(
             of the width being comprised of the turn.
         num_pts (int): number of polygon points to use for turn
         extend_terminals (bool): If True, bring ports flush to edges of device
+            also allows shorter device by overlapping hairpins.
         terminals_same_side (bool): If True, both ports will be located on the
             same side of the SNSPD.
         layer (LayerSpec): GDS layer specification
@@ -81,14 +82,17 @@ def basic(
 
     num_meanders = int(np.ceil(ysize / wire_pitch))
 
-    half_size = xsize / 2
+    if extend_terminals:
+        hairpin_length = xsize
+    else:
+        hairpin_length = xsize / 2
 
     SNSPD = Device()
     hairpin = qg.geometries.optimal_hairpin(
         width=wire_width,
         pitch=wire_pitch,
         turn_ratio=turn_ratio,
-        length=half_size,
+        length=hairpin_length,
         num_pts=num_pts,
         layer=layer,
     )
@@ -98,15 +102,8 @@ def basic(
     elif terminals_same_side and (num_meanders % 2) == 1:
         num_meanders += 1
 
-    if extend_terminals:
-        start_nw = SNSPD.add_ref(
-            pg.straight(size=(wire_width, half_size), layer=qg.get_layer(layer))
-        )
-        hp_prev = SNSPD.add_ref(hairpin)
-        hp_prev.connect(1, start_nw.ports[2])
-    else:
-        start_nw = SNSPD.add_ref(hairpin)
-        hp_prev = start_nw
+    start_nw = SNSPD.add_ref(hairpin)
+    hp_prev = start_nw
     alternate = True
     last_port = None
     for _n in range(2, num_meanders):
@@ -115,19 +112,14 @@ def basic(
             hp.connect(2, hp_prev.ports[2])
         else:
             hp.connect(1, hp_prev.ports[1])
+        if extend_terminals:
+            # inset
+            hp.movex(hp_prev.xmin - hp.xmin)
         last_port = hp.ports[2] if terminals_same_side else hp.ports[1]
         hp_prev = hp
         alternate = not alternate
 
-    if extend_terminals:
-        finish_se = SNSPD.add_ref(
-            pg.straight(size=(wire_width, half_size), layer=qg.get_layer(layer))
-        )
-        if last_port is not None:
-            finish_se.connect(2, last_port)
-        SNSPD.add_port(port=finish_se.ports[1], name=2, layer=layer)
-    else:
-        SNSPD.add_port(port=last_port, name=2, layer=layer)
+    SNSPD.add_port(port=last_port, name=2, layer=layer)
 
     SNSPD.add_port(port=start_nw.ports[1], name=1, layer=layer)
 

--- a/src/qnngds/experiment.py
+++ b/src/qnngds/experiment.py
@@ -28,7 +28,7 @@ class RouteGroup:
 
     Stores a cross section and mapping of DUT ports to optional pad
     ports. If a DUT port is mapped to None, then a pad port
-    will be automatically assigned in :py:func:`generate_experiment`
+    will be automatically assigned in :py:func:`generate`
     """
 
     def __init__(
@@ -71,7 +71,7 @@ class RouteGroup:
 def _get_segment_from_path(path: Path, p: int) -> ArrayLike:
     """Gets the segment starting from the p'th point in path.
 
-    Helper method for :py:func:`generate_experiment`.
+    Helper method for :py:func:`generate`.
 
     Args:
         path (Path): path to get segment from
@@ -87,7 +87,7 @@ def _get_segment_from_path(path: Path, p: int) -> ArrayLike:
 def _segments_overlap(segment_1: ArrayLike, segment_2: ArrayLike) -> bool:
     """Determines if two line segments on a manhattan grid overlap.
 
-    Helper method for :py:func:`generate_experiment`.
+    Helper method for :py:func:`generate`.
 
     Args:
         segment_1 (ArrayLike): first segment
@@ -109,7 +109,7 @@ def _segments_overlap(segment_1: ArrayLike, segment_2: ArrayLike) -> bool:
 def _path_self_intersects(path: Path) -> bool:
     """Determines if a manhattan path has any self-intersections
 
-    Helper method for :py:func:`generate_experiment`.
+    Helper method for :py:func:`generate`.
 
     Args:
         path (Path): path to check
@@ -131,7 +131,7 @@ def _path_self_intersects(path: Path) -> bool:
 def _paths_intersect(path_1: Path, path_2: Path) -> bool:
     """Determines if two manhattan paths intersect
 
-    Helper method for :py:func:`generate_experiment`.
+    Helper method for :py:func:`generate`.
 
     Args:
         path_1 (Path): first path to check
@@ -156,7 +156,7 @@ def _sort_ports(
 ) -> Sequence[Port]:
     """Sorts collections of ports all facing the same direction.
 
-    Helper method for :py:func:`generate_experiment`.
+    Helper method for :py:func:`generate`.
 
     Args:
         ports (dict[str, Sequence[Port]): dictionary of ports.
@@ -367,6 +367,7 @@ def _route_dut(
     layer_transitions: dict[tuple, DeviceSpec],
     retries: int,
     ignore_dut_bbox: bool,
+    debug: bool,
 ) -> Device:
     """Helper method for :py:`generate`
 
@@ -379,6 +380,7 @@ def _route_dut(
         layer_transitions (dict[tuple, DeviceSpec]): transitions between layers
         retries (int): max number of retries
         ignore_dut_bbox (bool): whether or not to ignore the dut bounding box when routing
+        debug (bool): if True, generate quickplot before throwing error
 
     Returns:
         (Device): the routed device
@@ -431,6 +433,7 @@ def _route_dut(
                         if len(portmap[0]) == 0:
                             continue
                         for port1, port2 in zip(portmap[0], portmap[1]):
+                            print(port1, port2)
                             route_path = pr.path_manhattan(
                                 port1, port2, radius=xc.radius
                             )
@@ -452,6 +455,10 @@ def _route_dut(
                     complete = False
                     continue
                 except ValueError as e:
+                    if debug:
+                        from phidl import quickplot as qp
+
+                        qp(routed)
                     raise RuntimeError(
                         "Routing failed, try manually specifying port mapping "
                         "between DUT and pads with route_groups."
@@ -480,13 +487,14 @@ def generate(
     dut: DeviceSpec | Device,
     pad_array: DeviceSpec | Device,
     label: DeviceSpec | Device | None,
-    route_groups: Sequence[RouteGroup] | None,
+    route_groups: Sequence[RouteGroup],
     dut_offset: tuple[float, float] = (0, 0),
     pad_offset: tuple[float, float] = (0, 0),
     label_offset: tuple[float, float] | None = (-100, -100),
     ignore_port_count_mismatch: bool = False,
     ignore_dut_bbox: bool = False,
     retries: int = 10,
+    debug: bool = False,
 ) -> Device:
     """Construct an experiment from a device/circuit (Device).
 
@@ -496,7 +504,7 @@ def generate(
         dut (DeviceSpec or Device): finished device to be connected to pads
         pad_array (DeviceSpec or Device or None): pad array to connect to device
         label (DeviceSpec or Device or None): text label or factory.
-        route_groups (Sequence[RouteGroup] or None): how to route DUT to pads
+        route_groups (Sequence[RouteGroup]): how to route DUT to pads
         dut_offset (tuple[float, float]): x,y offset for dut (mostly useful for linear pad arrays)
         pad_offset (tuple[float, float]): x,y offset for pad array (mostly useful for linear pad arrays)
         label_offset (tuple[float, float] or None): x,y offset of label
@@ -504,6 +512,8 @@ def generate(
             only if route_groups defines a mapping to all pad ports, or lists all DUT ports.
         ignore_dut_bbox (bool): if True, does not attempt to route around DUT bounding box (bbox)
         retries (int): how many times to try rerouting with s_bend (may need to be larger for many port groupings)
+        debug (bool): if True, quickplot DUT + pads before throwing error when routing fails
+
     Returns:
         (Device): experiment
 
@@ -687,5 +697,6 @@ def generate(
         layer_transitions=layer_transitions,
         retries=retries,
         ignore_dut_bbox=ignore_dut_bbox,
+        debug=debug,
     )
     return routed

--- a/src/qnngds/experiment.py
+++ b/src/qnngds/experiment.py
@@ -636,7 +636,9 @@ def generate(
             pad_port = dut_pad_map[dut_port_name]
             if (dut_port.orientation - pad_port.orientation) % 360 == 180:
                 # ports are facing each other
-                w_route = route_group.cross_section.sections[0]["width"]
+                w_route = qg.get_cross_section(route_group.cross_section).sections[0][
+                    "width"
+                ]
                 w_pad = pad_port.width
                 dw = w_pad - w_route
                 dwidth = 0

--- a/src/qnngds/experiment.py
+++ b/src/qnngds/experiment.py
@@ -433,7 +433,6 @@ def _route_dut(
                         if len(portmap[0]) == 0:
                             continue
                         for port1, port2 in zip(portmap[0], portmap[1]):
-                            print(port1, port2)
                             route_path = pr.path_manhattan(
                                 port1, port2, radius=xc.radius
                             )

--- a/src/qnngds/experiment.py
+++ b/src/qnngds/experiment.py
@@ -434,7 +434,7 @@ def _route_dut(
                             continue
                         for port1, port2 in zip(portmap[0], portmap[1]):
                             route_path = pr.path_manhattan(
-                                port1, port2, radius=xc.radius
+                                port1, port2, radius=1.5 * xc.radius
                             )
                             route_path = pp.smooth(
                                 route_path, radius=xc.radius, use_eff=False, num_pts=50

--- a/src/qnngds/geometries.py
+++ b/src/qnngds/geometries.py
@@ -369,7 +369,7 @@ def fillet_90deg(
         taper_radius (float | None) : radius of taper. If None, uses stub_size
         layer (LayerSpec): Specification of layer(s) to put polygon geometry on.
     Returns:
-        (Device): tee
+        (Device): fillet_90deg
     """
 
     f = np.array(size).astype(np.float64)

--- a/src/qnngds/geometries.py
+++ b/src/qnngds/geometries.py
@@ -60,6 +60,49 @@ def taper(
 
 
 @qg.device
+def ramp(
+    length: int | float = 10,
+    start_width: int | float = 5,
+    end_width: int | float = 2,
+    layer: LayerSpec = (1, 0),
+) -> Device:
+    """Linear ramp (solid). Asymmetric version of taper.
+
+    Args:
+        length (int or float): Length of ramp
+        start_width (int or float): Width of first end of ramp
+        end_width (int or float): Width of second end of ramp
+        layer (LayerSpec): GDS layer specification
+
+    Returns:
+        (Device): a single taper
+    """
+    T = Device("taper")
+    pts = [
+        (0, 0),
+        (length, 0),
+        (length, end_width),
+        (0, start_width),
+    ]
+    T.add_polygon(pts, layer=qg.get_layer(layer))
+    T.add_port(
+        name=1,
+        midpoint=[0, start_width / 2],
+        width=start_width,
+        orientation=180,
+        layer=layer,
+    )
+    T.add_port(
+        name=2,
+        midpoint=[length, end_width / 2],
+        width=end_width,
+        orientation=0,
+        layer=layer,
+    )
+    return T
+
+
+@qg.device
 def hyper_taper(
     length: int | float = 10,
     start_width: int | float = 5,

--- a/src/qnngds/test_structures.py
+++ b/src/qnngds/test_structures.py
@@ -428,7 +428,6 @@ def vdp(
     diagonal: float = 400,
     contact_width: float = 40,
     layer: LayerSpec = (1, 0),
-    port_type: str = "electrical",
 ) -> Device:
     """Creates a Van der Pauw (VDP) device with specified dimensions.
 
@@ -436,7 +435,6 @@ def vdp(
         diagonal (float): Length of the VDP device, overall maximum dimension, in µm.
         contact_width (float): Width of the contact points (width of the ports), in µm.
         layer (LayerSpec): GDS layer specification
-        port_type (string): gdsfactory port type. default "electrical"
 
     Returns:
         (Device): Van der Pauw cell


### PR DESCRIPTION
allow shorter SNSPDs by overlapping hairpins, useful for meanders/kinetic inductors. allow asymmetric ntron.sharp

# Before merging the pull request, please confirm the following
- [x] You have read the contribution guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html)
- [x] All newly defined `Device`s are tagged with the `@qg.device` decorator.
- [x] You have verified the documentation looks okay on readthedocs. See the linked action  in this PR labeled "docs/readthedocs.org:qnngds" for a link.
- [x] You have chosen an appropriate semantic version following the guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html#satisfied-with-your-code-ready-for-a-pull-request) and have updated pyproject.toml accordingly
