### PR TITLE
Improve utilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,13 @@ jobs:
         python-version: 3.12
     - name: Ruff lint
       uses: astral-sh/ruff-action@v3
+      with:
+        version: "0.11.7"
     - name: Black lint
       uses: psf/black@stable
       with:
         options: "--check --verbose"
-        version: "25.12"
+        version: "25.12.0"
   verify-version:
     name: Check pyproject.toml version is updated
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 [project]
 name = "qnngds"
 
-version = "5.1.9"
+version = "5.1.10"
 
 authors = [
   { name="A. Jacquillat", email="audrey01@mit.edu" },

--- a/src/qnngds/__init__.py
+++ b/src/qnngds/__init__.py
@@ -16,6 +16,7 @@ from .pdk import (
     Pdk as Pdk,
     get_active_pdk as get_active_pdk,
     get_layer as get_layer,
+    get_layer_tuple as get_layer_tuple,
     get_device as get_device,
     get_cross_section as get_cross_section,
     layer_auto_transitions as layer_auto_transitions,

--- a/src/qnngds/pdk.py
+++ b/src/qnngds/pdk.py
@@ -79,11 +79,13 @@ class Pdk:
         """Enable the PDK and allow it to be accessed globally"""
         _set_active_pdk(self)
 
-    def get_layer(self, layer: LayerSpec) -> Layer:
+    def get_layer(self, layer: LayerSpec, allow_unknown: bool = False) -> Layer:
         """Get a specific layer within the PDK
 
         Args:
             layer (LayerSpec): string, int, or tuple that identifies the desired layer
+            allow_unknown (bool): if True, will return the a provided tuple layerspec if
+                it does not match any layers registered in the active PDK.
 
         Returns:
             (Layer): instance of layer matching the queried LayerSpec
@@ -109,6 +111,8 @@ class Pdk:
                 _layer = self.layers[_layer]
                 if layer == (_layer.gds_layer, _layer.gds_datatype):
                     return _layer
+            if allow_unknown:
+                return layer
         raise ValueError(value_error_msg)
 
     def get_device(self, spec: DeviceSpec, **kwargs: dict) -> phidl.Device:
@@ -268,7 +272,27 @@ def get_layer(layer: LayerSpec) -> Layer:
     Returns:
         (Layer): instance of layer matching the queried LayerSpec
     """
-    return get_active_pdk().get_layer(layer)
+    return get_active_pdk().get_layer(layer, allow_unknown=False)
+
+
+def get_layer_tuple(layer: LayerSpec) -> tuple:
+    """Convert a LayerSpec to a tuple.
+
+    The LayerSpec need not correspond to an existing layer in the PDK.
+
+    Args:
+        layer (LayerSpec): string, int, or tuple that identifies the desried layer
+
+    Returns:
+        (tuple[int, int]): gds layer, datatype tuple
+    """
+    layer_parsed = get_active_pdk().get_layer(layer, allow_unknown=True)
+    if isinstance(layer_parsed, Layer):
+        return layer_parsed.tuple
+    elif isinstance(layer_parsed, tuple):
+        return layer_parsed
+    else:
+        raise ValueError(f"could not get tuple form of layer {layer}")
 
 
 def get_device(spec: DeviceSpec, **kwargs: dict) -> phidl.Device:

--- a/src/qnngds/utilities.py
+++ b/src/qnngds/utilities.py
@@ -10,10 +10,112 @@ from functools import partial
 import numpy as np
 
 from qnngds.typing import LayerSpec, LayerSpecs, DeviceSpec, CrossSectionSpec
-from qnngds import Device, LayerSet, Port
+from qnngds import Device, LayerSet, Port, Layer
 
 import qnngds as qg
 import phidl.geometry as pg
+
+
+def fill_grid(
+    device: Device,
+    avoid_layers: LayerSpecs,
+    include_layers: None | LayerSpecs,
+    margin: float,
+    fill_layers: LayerSpecs,
+    fill_size: tuple,
+    fill_densities: Sequence[float],
+    fill_inverted: bool,
+    bbox: tuple,
+) -> Device:
+    """Creates rectangularly-gridded fill, similar to pg.fill_rectangle
+
+    Parameters
+        device (Device): device to outline
+        avoid_layers (LayerSpecs): layers to avoid
+        include_layers (LayerSpecs): layers to connect to
+        margin (float): distance from avoid_layers
+        fill_layers (LayerSpecs): layers to add fill to
+        fill_size (tuple): (width, height) of grid
+        fill_densities (Sequence[float]) density for each fill layer
+        fill_inverted (bool): if True, produces a connected mesh, if False, a grid of rectangles
+        bbox (tuple): bounding box to extend fill to
+
+    Returns:
+        (Device): fill
+    """
+    MASK = fill_solid(
+        device=device,
+        avoid_layers=avoid_layers,
+        include_layers=include_layers,
+        margin=margin,
+        fill_layers=(0,),
+        bbox=bbox,
+    )
+    D = Device("fill_grid")
+    for fill_density, layer in zip(fill_densities, fill_layers):
+        GRID = Device("grid")
+        rect = pg.rectangle(size=np.array(fill_size) * fill_densities, layer=0)
+        GRID.add_array(
+            rect,
+            columns=int(np.ceil(MASK.xsize / fill_size[0])),
+            rows=int(np.ceil(MASK.ysize / fill_size[1])),
+            spacing=fill_size,
+        )
+        GRID.center = MASK.center
+        D << pg.kl_boolean(
+            MASK,
+            GRID,
+            operation="-" if fill_inverted else "and",
+            layer=qg.get_layer(layer),
+        )
+    return D
+
+
+def fill_solid(
+    device: Device,
+    avoid_layers: LayerSpecs,
+    include_layers: None | LayerSpecs,
+    margin: float,
+    fill_layers: LayerSpecs,
+    bbox: tuple,
+) -> Device:
+    """Fill around a device.
+
+    Parameters:
+        device (Device): device to outline
+        avoid_layers (LayerSpecs): layers to avoid
+        include_layers (LayerSpecs): layers to connect to
+        margin (float): distance from avoid_layers
+        fill_layers (LayerSpecs): layers to add fill to
+        bbox (tuple): bounding box to extend fill to
+
+    Returns:
+        (Device): fill
+    """
+    BBOX = pg.bbox(bbox)
+    AVOID = Device("avoid")
+    INCLUDE = Device("include")
+    polygons = device.get_polygons(by_spec=True)
+    for device, layerset in zip((AVOID, INCLUDE), (avoid_layers, include_layers)):
+        for layer in layerset:
+            if isinstance(layer, int):
+                layer = (layer, 0)
+            if isinstance(layer, str):
+                layer = qg.get_layer(layer).tuple
+            if isinstance(layer, Layer):
+                layer = layer.tuple
+            device.add_polygon(polygons[layer])
+    AVOID_MASKED = pg.kl_boolean(AVOID, INCLUDE, operation="A-B")
+    AVOID_SIZED = pg.offset(AVOID_MASKED, distance=margin, join="bevel")
+    FILL = Device("fill")
+    fill_poly = pg.kl_boolean(
+        BBOX, AVOID_SIZED, operation="A-B", layer=0
+    ).get_polygons()
+    for layer in fill_layers:
+        if isinstance(layer, str):
+            layer = qg.get_layer(layer)
+        FILL.add_polygon(fill_poly, layer=layer)
+    return FILL
 
 
 def extend_ports(

--- a/src/qnngds/utilities.py
+++ b/src/qnngds/utilities.py
@@ -10,7 +10,7 @@ from functools import partial
 import numpy as np
 
 from qnngds.typing import LayerSpec, LayerSpecs, DeviceSpec, CrossSectionSpec
-from qnngds import Device, LayerSet, Port, Layer
+from qnngds import Device, LayerSet, Port
 
 import qnngds as qg
 import phidl.geometry as pg
@@ -98,23 +98,21 @@ def fill_solid(
     polygons = device.get_polygons(by_spec=True)
     for device, layerset in zip((AVOID, INCLUDE), (avoid_layers, include_layers)):
         for layer in layerset:
-            if isinstance(layer, int):
-                layer = (layer, 0)
-            if isinstance(layer, str):
-                layer = qg.get_layer(layer).tuple
-            if isinstance(layer, Layer):
-                layer = layer.tuple
-            device.add_polygon(polygons[layer])
-    AVOID_MASKED = pg.kl_boolean(AVOID, INCLUDE, operation="A-B")
+            layer = qg.get_layer_tuple(layer)
+            if layer in polygons:
+                device.add_polygon(polygons[layer])
+    INCLUDE_SIZED = pg.offset(INCLUDE, distance=1e-2, join="bevel")
+    AVOID_MASKED = pg.kl_boolean(AVOID, INCLUDE_SIZED, operation="A-B")
     AVOID_SIZED = pg.offset(AVOID_MASKED, distance=margin, join="bevel")
     FILL = Device("fill")
     fill_poly = pg.kl_boolean(
         BBOX, AVOID_SIZED, operation="A-B", layer=0
     ).get_polygons()
-    for layer in fill_layers:
-        if isinstance(layer, str):
-            layer = qg.get_layer(layer)
-        FILL.add_polygon(fill_poly, layer=layer)
+    if len(fill_poly) > 0:
+        for layer in fill_layers:
+            if isinstance(layer, str):
+                layer = qg.get_layer(layer)
+            FILL.add_polygon(fill_poly, layer=layer)
     return FILL
 
 
@@ -328,7 +326,7 @@ def outline(
     polygons = device.get_polygons(by_spec=True)
     extended_polygons = dev_extended.get_polygons(by_spec=True)
     for layer, poly in polygons.items():
-        layer = qg.get_layer(layer).tuple
+        qg.get_layer_tuple(layer)
         if layer not in outline_layers:
             dev_outlined.add_polygon(poly, layer=layer)
         else:
@@ -380,10 +378,10 @@ def invert(
     """
     tile_size = None if kl_tile_size is None else (kl_tile_size, kl_tile_size)
     dev_inverted = Device()
-    ext_bbox_distance = {qg.get_layer(k).tuple: v for k, v in ext_bbox_distance.items()}
+    ext_bbox_distance = {qg.get_layer_tuple(k): v for k, v in ext_bbox_distance.items()}
     polygons = device.get_polygons(by_spec=True)
     for layer, poly in polygons.items():
-        layer = qg.get_layer(layer).tuple
+        layer = qg.get_layer_tuple(layer)
         if layer not in ext_bbox_distance:
             dev_inverted.add_polygon(poly, layer=layer)
         else:
@@ -440,8 +438,8 @@ def keepout(
     if outline_layers is None:
         outline_layers = {}
 
-    outline_layers = {qg.get_layer(k).tuple: v for k, v in outline_layers.items()}
-    keepout_layers = {qg.get_layer(k).tuple: v for k, v in keepout_layers.items()}
+    outline_layers = {qg.get_layer_tuple(k): v for k, v in outline_layers.items()}
+    keepout_layers = {qg.get_layer_tuple(k): v for k, v in keepout_layers.items()}
     processed_layers = set([])
 
     polygons = device.get_polygons(by_spec=True)
@@ -450,7 +448,7 @@ def keepout(
             continue
         keepout_poly = polygons[keepout_layer]
         for mapped_layer in mapped_layers:
-            mapped_layer = qg.get_layer(mapped_layer).tuple
+            mapped_layer = qg.get_layer_tuple(mapped_layer)
             neg_tone = mapped_layer not in outline_layers
             d_keepout = Device()
             d_keepout.add_polygon(keepout_poly, layer=mapped_layer)
@@ -490,7 +488,7 @@ def keepout(
             processed_layers.add(mapped_layer)
     # add remaining layers
     for layer in device.layers:
-        layer = qg.get_layer(layer).tuple
+        layer = qg.get_layer_tuple(layer)
         if layer in processed_layers:
             continue
         if layer in keepout_layers:

--- a/test/test.py
+++ b/test/test.py
@@ -15,6 +15,7 @@ helper_functions = [
     "get_cross_section",
     "get_device",
     "get_layer",
+    "get_layer_tuple",
     "get_outline_layers",
     "layer_auto_transitions",
     "outline",

--- a/test/test.py
+++ b/test/test.py
@@ -28,6 +28,8 @@ helper_functions = [
     "outline",
     "to_qg_device",
     "create_layered_ports",
+    "fill_grid",
+    "fill_solid",
 ]
 
 


### PR DESCRIPTION
Fill_rectangle is kinda slow, also very blocky. For continuous fill (i.e. with fill_density=1), it makes more sense to use klayout boolean and shape operations.

Also allow processing of unregistered layers for experiment.generate and utilities.{keepout,outline,invert}

# Before merging the pull request, please confirm the following
- [x] You have read the contribution guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html)
- [x] All newly defined `Device`s are tagged with the `@qg.device` decorator.
- [x] You have verified the documentation looks okay on readthedocs. See the linked action  in this PR labeled "docs/readthedocs.org:qnngds" for a link.
- [x] You have chosen an appropriate semantic version following the guidelines on [qnngds.readthedocs.io](https://qnngds.readthedocs.io/en/latest/src/contributing/contribute.html#satisfied-with-your-code-ready-for-a-pull-request) and have updated pyproject.toml accordingly
